### PR TITLE
change auth0 redirect url

### DIFF
--- a/cookbook/src/Auth/Auth.js
+++ b/cookbook/src/Auth/Auth.js
@@ -2,7 +2,7 @@ import auth0 from "auth0-js";
 
 // Change callback URL based on where the app is hosted
 let devEndpoint = "http://localhost:3000";
-let prodEndpoint = "https://lambda-cookbook.netlify.com";
+let prodEndpoint = "https://www.your-cookbook.us";
 
 class Auth {
   constructor() {


### PR DESCRIPTION
Auth0 production endpoint has been changed to the new deployment at `https://www.your-cookbook.us`.